### PR TITLE
Introduce bytes::Bytes for Vec<u8> columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,20 +1904,19 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -4373,11 +4372,11 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07b0a1390e01c0fc35ebb26b28ced33c9a3808f7f9fbe94d3cc01e233bfeed5"
+checksum = "b92f40481c04ff1f4f61f304d61793c7b56ff76ac1469f1beb199b1445b253bd"
 dependencies = [
- "idna 0.2.3",
+ "idna 0.4.0",
  "lazy_static",
  "regex",
  "serde",
@@ -4389,9 +4388,9 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7ed5e8cf2b6bdd64a6c4ce851da25388a89327b17b88424ceced6bd5017923"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
 dependencies = [
  "if_chain",
  "lazy_static",
@@ -4405,9 +4404,9 @@ dependencies = [
 
 [[package]]
 name = "validator_types"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ddf34293296847abfc1493b15c6e2f5d3cd19f57ad7d22673bf4c6278da329"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",

--- a/cotoami_db/Cargo.toml
+++ b/cotoami_db/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0"
 tracing = "0.1"
 url = "2.3.1"
 uuid = {version = "1.3.2", features = ["v4", "serde"]}
-validator = {version = "0.15", features = ["derive"]}
+validator = {version = "0.16.1", features = ["derive"]}
 
 # Add support for RETURNING expressions for Sqlite via the returning_clauses_for_sqlite_3_35 feature
 diesel = {version = "2.1.0", features = ["sqlite", "chrono", "returning_clauses_for_sqlite_3_35"]}

--- a/cotoami_db/src/models.rs
+++ b/cotoami_db/src/models.rs
@@ -17,6 +17,7 @@ use diesel::{
     sqlite::Sqlite,
     FromSqlRow,
 };
+use serde::Deserializer;
 use uuid::Uuid;
 
 use self::{node::parent::ParentNode, operator::Operator};
@@ -184,8 +185,17 @@ impl<T> FromSql<Text, Sqlite> for Ids<T> {
 #[serde(transparent)]
 pub struct Bytes(bytes::Bytes);
 
+impl Bytes {
+    fn from_base64<'de, D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        crate::from_base64(deserializer).map(Bytes::from)
+    }
+}
+
 impl AsRef<[u8]> for Bytes {
-    fn as_ref(&self) -> &[u8] { self.as_ref() }
+    fn as_ref(&self) -> &[u8] { self.0.as_ref() }
 }
 
 impl From<Vec<u8>> for Bytes {

--- a/cotoami_db/src/models/node.rs
+++ b/cotoami_db/src/models/node.rs
@@ -49,7 +49,7 @@ pub struct Node {
     /// Icon image
     #[serde(
         serialize_with = "crate::as_base64",
-        deserialize_with = "crate::from_base64"
+        deserialize_with = "Bytes::from_base64"
     )]
     #[debug(skip)]
     pub icon: Bytes,
@@ -78,7 +78,7 @@ impl Node {
     pub fn to_update(&self) -> UpdateNode {
         UpdateNode {
             uuid: &self.uuid,
-            icon: &self.icon,
+            icon: self.icon.as_ref(),
             name: &self.name,
             root_cotonoma_id: self.root_cotonoma_id.as_ref(),
             version: self.version + 1, // increment the version
@@ -153,7 +153,7 @@ impl<'a> NewNode<'a> {
 #[diesel(table_name = nodes, primary_key(uuid))]
 pub struct ImportNode<'a> {
     uuid: &'a Id<Node>,
-    icon: &'a Vec<u8>,
+    icon: &'a Bytes,
     name: &'a str,
     root_cotonoma_id: Option<&'a Id<Cotonoma>>,
     version: i32,
@@ -170,7 +170,7 @@ pub struct ImportNode<'a> {
 pub struct UpdateNode<'a> {
     uuid: &'a Id<Node>,
     #[validate(length(max = "Node::ICON_MAX_LENGTH"))]
-    pub icon: &'a Vec<u8>,
+    pub icon: &'a [u8],
     #[validate(length(max = "Node::NAME_MAX_LENGTH"))]
     pub name: &'a str,
     pub root_cotonoma_id: Option<&'a Id<Cotonoma>>,

--- a/cotoami_db/tests/init_test.rs
+++ b/cotoami_db/tests/init_test.rs
@@ -256,7 +256,7 @@ fn init_as_node() -> Result<()> {
 }
 
 fn assert_icon_generated(node: &Node) -> Result<()> {
-    let image = image::load_from_memory_with_format(&node.icon, ImageFormat::Png)?;
+    let image = image::load_from_memory_with_format(node.icon.as_ref(), ImageFormat::Png)?;
     assert_eq!(image.width(), 600);
     assert_eq!(image.height(), 600);
     Ok(())

--- a/cotoami_node/Cargo.toml
+++ b/cotoami_node/Cargo.toml
@@ -35,4 +35,4 @@ tower-service = "0.3.2"
 tracing = "0.1" 
 tracing-subscriber = "0.3" 
 uuid = {version = "1.3.2", features = ["v4", "serde"]} 
-validator = {version = "0.15", features = ["derive"]}
+validator = {version = "0.16.1", features = ["derive"]}


### PR DESCRIPTION
* It aims at making cloning entity structs that contain `Vec<u8>` fields cheaper.
* `cotoami_db::models::Bytes`
    * wrapping `bytes::Bytes` to implements `ToSql` / `FromSql`