### PR TITLE
Fix a design flaw in Change::Promote

### DIFF
--- a/cotoami_node/crates/db/src/db/ops/changelog_ops.rs
+++ b/cotoami_node/crates/db/src/db/ops/changelog_ops.rs
@@ -228,8 +228,9 @@ fn apply_change<'a>(
             Change::Promote {
                 coto_id,
                 promoted_at,
+                cotonoma_id,
             } => {
-                coto_ops::promote(coto_id, Some(*promoted_at)).run(ctx)?;
+                coto_ops::promote(coto_id, Some(*promoted_at), *cotonoma_id).run(ctx)?;
             }
             Change::DeleteCoto {
                 coto_id,

--- a/cotoami_node/crates/db/src/db/transactions/cotos.rs
+++ b/cotoami_node/crates/db/src/db/transactions/cotos.rs
@@ -178,12 +178,13 @@ impl DatabaseSession<'_> {
             operator.can_update_coto(&coto)?;
 
             // Do promote
-            let (cotonoma, coto) = coto_ops::promote(coto_id, None).run(ctx)?;
+            let (cotonoma, coto) = coto_ops::promote(coto_id, None, None).run(ctx)?;
 
             // Log change
             let change = Change::Promote {
                 coto_id: *coto_id,
                 promoted_at: cotonoma.created_at,
+                cotonoma_id: Some(cotonoma.uuid),
             };
             let changelog = changelog_ops::log_change(&change, &local_node_id).run(ctx)?;
 

--- a/cotoami_node/crates/db/src/models/changelog.rs
+++ b/cotoami_node/crates/db/src/models/changelog.rs
@@ -124,6 +124,10 @@ pub enum Change {
     Promote {
         coto_id: Id<Coto>,
         promoted_at: NaiveDateTime,
+        // Before v0.8.0, cotonoma_id was not included in this change because of
+        // a wrong design decision, which caused cotonoma_id mismatch among nodes
+        // in a network.
+        cotonoma_id: Option<Id<Cotonoma>>,
     },
     DeleteCoto {
         coto_id: Id<Coto>,

--- a/cotoami_node/crates/db/src/models/cotonoma.rs
+++ b/cotoami_node/crates/db/src/models/cotonoma.rs
@@ -112,6 +112,21 @@ impl<'a> NewCotonoma<'a> {
         cotonoma.validate()?;
         Ok(cotonoma)
     }
+
+    pub fn promoted_from(
+        coto: &'a Coto,
+        promoted_at: NaiveDateTime,
+        cotonoma_id: Option<Id<Cotonoma>>,
+    ) -> Self {
+        Self {
+            uuid: cotonoma_id.unwrap_or(Id::generate()),
+            node_id: &coto.node_id,
+            coto_id: &coto.uuid,
+            name: coto.name_as_cotonoma().unwrap(),
+            created_at: promoted_at,
+            updated_at: promoted_at,
+        }
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/cotoami_node/crates/db/src/models/cotonoma.rs
+++ b/cotoami_node/crates/db/src/models/cotonoma.rs
@@ -117,15 +117,17 @@ impl<'a> NewCotonoma<'a> {
         coto: &'a Coto,
         promoted_at: NaiveDateTime,
         cotonoma_id: Option<Id<Cotonoma>>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self> {
+        let cotonoma = Self {
             uuid: cotonoma_id.unwrap_or(Id::generate()),
             node_id: &coto.node_id,
             coto_id: &coto.uuid,
             name: coto.name_as_cotonoma().unwrap(),
             created_at: promoted_at,
             updated_at: promoted_at,
-        }
+        };
+        cotonoma.validate()?;
+        Ok(cotonoma)
     }
 }
 


### PR DESCRIPTION
Because `Change::Promote` doesn't contain the data of the newly created cotonoma, it causes promoted cotonoma ID mismatch between the node where the change occurred and its child nodes. For example, you can't post a coto to a remote cotonoma that has been promoted from a coto due to this issue (it will cause "cotonoma not found" error).



