### PR TITLE
Browsing Trail

### DIFF
--- a/cotoami_desktop/tauri/Info.plist
+++ b/cotoami_desktop/tauri/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/cotoami_desktop/tauri/src/commands/browser.rs
+++ b/cotoami_desktop/tauri/src/commands/browser.rs
@@ -325,10 +325,10 @@ pub fn browser_attach(
                     &content_label_for_page_load,
                 );
             })
-            .on_document_title_changed(move |_webview, title| {
+            .on_document_title_changed(move |webview, title| {
                 browser_registry_for_title.upsert(
                     &content_label_for_title,
-                    None,
+                    webview.url().ok().map(|url| url.to_string()),
                     Some(title),
                     None,
                 );

--- a/cotoami_desktop/tauri/src/commands/browser.rs
+++ b/cotoami_desktop/tauri/src/commands/browser.rs
@@ -56,11 +56,17 @@ impl BrowserRegistry {
     ) {
         let mut inner = self.inner.lock();
         let entry = inner.entry(content_label.to_string()).or_default();
+        let url_changed = url
+            .as_deref()
+            .zip(entry.url.as_deref())
+            .is_some_and(|(next, current)| next != current);
         if let Some(url) = url {
             entry.url = Some(url);
         }
         if let Some(title) = title {
             entry.title = Some(title);
+        } else if url_changed {
+            entry.title = None;
         }
         if let Some(is_loading) = is_loading {
             entry.is_loading = is_loading;

--- a/cotoami_desktop/tauri/tauri.conf.json
+++ b/cotoami_desktop/tauri/tauri.conf.json
@@ -56,8 +56,9 @@
     ],
     "macOS": {
       "entitlements": "./Entitlements.plist",
-      "exceptionDomain": "",
+      "exceptionDomain": "localhost",
       "frameworks": [],
+      "infoPlist": "./Info.plist",
       "providerShortName": null,
       "signingIdentity": "-"
     },

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -275,10 +275,12 @@ div.browser-shell {
       radial-gradient(circle at top left, color-mix(in srgb, var(--primary) 7%, transparent), transparent 35%),
       linear-gradient(180deg, color-mix(in srgb, var(--background-color) 96%, black 4%), var(--background-color));
 
-    > .split-pane.browser-main {
+    > .split-pane.browser-main,
+    .browser-history-secondary > .split-pane.browser-main {
       width: 100%;
       height: 100%;
       min-width: 0;
+      min-height: 0;
     }
 
     > .split-pane.browser-with-history {
@@ -292,6 +294,12 @@ div.browser-shell {
     .browser-webview-slot {
       min-width: 0;
       min-height: 0;
+    }
+
+    .browser-history-secondary {
+      display: flex;
+      width: 100%;
+      height: 100%;
     }
 
     .browser-history-sidebar {

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -64,6 +64,11 @@ div.browser-shell {
         color: var(--primary);
       }
 
+      &.active {
+        background: color-mix(in srgb, var(--primary) 18%, var(--card-background-color));
+        color: var(--primary);
+      }
+
       &.go {
         color: var(--primary);
         background: color-mix(in srgb, var(--primary) 8%, var(--card-background-color));

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -36,7 +36,7 @@ div.browser-shell {
       flex-shrink: 0;
     }
 
-    .browser-history-tool {
+    .browser-trail-tool {
       position: relative;
       display: inline-flex;
       align-items: center;
@@ -78,7 +78,7 @@ div.browser-shell {
       }
     }
 
-    .browser-history-menu {
+    .browser-trail-menu {
       width: min(34rem, calc(100vw - 1.5rem));
       max-height: min(28rem, calc(100vh - 6.5rem));
       overflow-y: auto;
@@ -89,13 +89,13 @@ div.browser-shell {
       box-shadow: 0 18px 42px color-mix(in srgb, var(--contrast) 18%, transparent);
     }
 
-    .browser-history-menu-wrap {
+    .browser-trail-menu-wrap {
       display: flex;
       justify-content: flex-start;
       padding-left: 4.5rem;
     }
 
-    .browser-history-empty {
+    .browser-trail-empty {
       padding: 0.8rem 0.9rem;
       color: var(--muted-color);
       font-size: 0.86rem;
@@ -103,23 +103,23 @@ div.browser-shell {
       white-space: nowrap;
     }
 
-    .browser-history-groups,
-    .browser-history-list {
+    .browser-trail-groups,
+    .browser-trail-list {
       margin: 0;
       padding: 0;
       list-style: none;
     }
 
-    .browser-history-group + .browser-history-group {
+    .browser-trail-group + .browser-trail-group {
       margin-top: 0.35rem;
       padding-top: 0.35rem;
       border-top: 1px solid color-mix(in srgb, var(--primary) 9%, var(--pane-border-color));
     }
 
-    .browser-history-entry {
+    .browser-trail-entry {
       position: relative;
 
-      > button.browser-history-open {
+      > button.browser-trail-open {
         display: grid;
         grid-template-columns: 1.3rem minmax(0, 1fr);
         align-items: center;
@@ -142,30 +142,30 @@ div.browser-shell {
         }
       }
 
-      &.level-2 > button.browser-history-open {
+      &.level-2 > button.browser-trail-open {
         padding-left: 1.75rem;
       }
 
-      &.current > button.browser-history-open {
+      &.current > button.browser-trail-open {
         border-left: 3px solid var(--primary);
         background: color-mix(in srgb, var(--primary) 24%, var(--card-background-color));
         color: var(--primary);
         font-weight: 650;
 
-        .browser-history-title,
-        .browser-history-url {
+        .browser-trail-title,
+        .browser-trail-url {
           color: var(--primary);
         }
       }
 
-      &:hover .browser-history-delete,
-      &:focus-within .browser-history-delete {
+      &:hover .browser-trail-delete,
+      &:focus-within .browser-trail-delete {
         opacity: 1;
         pointer-events: auto;
       }
     }
 
-    .browser-history-favicon {
+    .browser-trail-favicon {
       position: relative;
       display: inline-flex;
       align-items: center;
@@ -190,13 +190,13 @@ div.browser-shell {
       }
     }
 
-    .browser-history-text {
+    .browser-trail-text {
       display: grid;
       gap: 0.08rem;
       min-width: 0;
     }
 
-    button.browser-history-delete {
+    button.browser-trail-delete {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -223,20 +223,20 @@ div.browser-shell {
       }
     }
 
-    .browser-history-title,
-    .browser-history-url {
+    .browser-trail-title,
+    .browser-trail-url {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       line-height: 1.2;
     }
 
-    .browser-history-title {
+    .browser-trail-title {
       font-size: 0.86rem;
       font-weight: 600;
     }
 
-    .browser-history-url {
+    .browser-trail-url {
       color: color-mix(in srgb, var(--muted-color) 74%, var(--background-color));
       font-size: 0.76rem;
       font-weight: 400;
@@ -323,47 +323,47 @@ div.browser-shell {
       linear-gradient(180deg, color-mix(in srgb, var(--background-color) 96%, black 4%), var(--background-color));
 
     > .split-pane.browser-main,
-    .browser-history-secondary > .split-pane.browser-main {
+    .browser-trail-secondary > .split-pane.browser-main {
       width: 100%;
       height: 100%;
       min-width: 0;
       min-height: 0;
     }
 
-    > .split-pane.browser-with-history {
+    > .split-pane.browser-with-trail {
       width: 100%;
       height: 100%;
       min-width: 0;
     }
 
     .browser-content,
-    .browser-history-secondary,
+    .browser-trail-secondary,
     .browser-webview-slot {
       min-width: 0;
       min-height: 0;
     }
 
-    .browser-history-secondary {
+    .browser-trail-secondary {
       display: flex;
       width: 100%;
       height: 100%;
     }
 
-    .browser-history-sidebar {
+    .browser-trail-sidebar {
       min-width: 260px;
       max-width: min(520px, 70vw);
       background: var(--background-color);
       border-right: 1px solid var(--pane-border-color);
     }
 
-    .browser-history-pane {
+    .browser-trail-pane {
       display: flex;
       flex-direction: column;
       height: 100%;
       min-height: 0;
     }
 
-    .browser-history-header {
+    .browser-trail-header {
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -406,37 +406,37 @@ div.browser-shell {
       }
     }
 
-    .browser-history-menu {
+    .browser-trail-menu {
       flex: 1;
       min-height: 0;
       overflow-y: auto;
       padding: 0.45rem;
     }
 
-    .browser-history-empty {
+    .browser-trail-empty {
       padding: 0.8rem 0.9rem;
       color: var(--muted-color);
       font-size: 0.86rem;
       text-align: center;
     }
 
-    .browser-history-groups,
-    .browser-history-list {
+    .browser-trail-groups,
+    .browser-trail-list {
       margin: 0;
       padding: 0;
       list-style: none;
     }
 
-    .browser-history-group + .browser-history-group {
+    .browser-trail-group + .browser-trail-group {
       margin-top: 0.35rem;
       padding-top: 0.35rem;
       border-top: 1px solid color-mix(in srgb, var(--primary) 9%, var(--pane-border-color));
     }
 
-    .browser-history-entry {
+    .browser-trail-entry {
       position: relative;
 
-      > button.browser-history-open {
+      > button.browser-trail-open {
         display: grid;
         grid-template-columns: 1.3rem minmax(0, 1fr);
         align-items: center;
@@ -459,30 +459,30 @@ div.browser-shell {
         }
       }
 
-      &.level-2 > button.browser-history-open {
+      &.level-2 > button.browser-trail-open {
         padding-left: 1.75rem;
       }
 
-      &.current > button.browser-history-open {
+      &.current > button.browser-trail-open {
         border-left: 3px solid var(--primary);
         background: color-mix(in srgb, var(--primary) 24%, var(--card-background-color));
         color: var(--primary);
         font-weight: 650;
 
-        .browser-history-title,
-        .browser-history-url {
+        .browser-trail-title,
+        .browser-trail-url {
           color: var(--primary);
         }
       }
 
-      &:hover .browser-history-delete,
-      &:focus-within .browser-history-delete {
+      &:hover .browser-trail-delete,
+      &:focus-within .browser-trail-delete {
         opacity: 1;
         pointer-events: auto;
       }
     }
 
-    .browser-history-favicon {
+    .browser-trail-favicon {
       position: relative;
       display: inline-flex;
       align-items: center;
@@ -507,13 +507,13 @@ div.browser-shell {
       }
     }
 
-    .browser-history-text {
+    .browser-trail-text {
       display: grid;
       gap: 0.08rem;
       min-width: 0;
     }
 
-    button.browser-history-delete {
+    button.browser-trail-delete {
       position: absolute;
       top: 50%;
       right: 0.4rem;
@@ -544,20 +544,20 @@ div.browser-shell {
       }
     }
 
-    .browser-history-title,
-    .browser-history-url {
+    .browser-trail-title,
+    .browser-trail-url {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       line-height: 1.2;
     }
 
-    .browser-history-title {
+    .browser-trail-title {
       font-size: 0.86rem;
       font-weight: 600;
     }
 
-    .browser-history-url {
+    .browser-trail-url {
       color: color-mix(in srgb, var(--muted-color) 74%, var(--background-color));
       font-size: 0.76rem;
       font-weight: 400;

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -36,6 +36,12 @@ div.browser-shell {
       flex-shrink: 0;
     }
 
+    .browser-history-tool {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+    }
+
     button.browser-action {
       display: inline-flex;
       align-items: center;
@@ -70,6 +76,121 @@ div.browser-shell {
       .material-symbols.loading {
         animation: browser-shell-spin 1.1s linear infinite;
       }
+    }
+
+    .browser-history-menu {
+      position: absolute;
+      top: calc(100% + 0.45rem);
+      left: 50%;
+      width: min(34rem, calc(100vw - 1.5rem));
+      max-height: min(28rem, calc(100vh - 6.5rem));
+      overflow-y: auto;
+      transform: translateX(-8rem);
+      padding: 0.45rem;
+      border: 1px solid color-mix(in srgb, var(--primary) 14%, var(--pane-border-color));
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--card-background-color) 98%, var(--background-color));
+      box-shadow: 0 18px 42px color-mix(in srgb, var(--contrast) 18%, transparent);
+    }
+
+    .browser-history-empty {
+      padding: 0.8rem 0.9rem;
+      color: var(--muted-color);
+      font-size: 0.86rem;
+      text-align: center;
+      white-space: nowrap;
+    }
+
+    .browser-history-groups,
+    .browser-history-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .browser-history-group + .browser-history-group {
+      margin-top: 0.35rem;
+      padding-top: 0.35rem;
+      border-top: 1px solid color-mix(in srgb, var(--primary) 9%, var(--pane-border-color));
+    }
+
+    .browser-history-entry {
+      button {
+        display: grid;
+        grid-template-columns: 1.3rem minmax(0, 1fr);
+        align-items: center;
+        gap: 0.55rem;
+        width: 100%;
+        min-height: 2.55rem;
+        margin: 0;
+        padding: 0.36rem 0.5rem;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--contrast);
+        box-shadow: none;
+        text-align: left;
+
+        &:hover,
+        &:focus {
+          background: var(--browser-tool-hover-background);
+          color: var(--contrast);
+        }
+      }
+
+      &.level-2 button {
+        padding-left: 1.75rem;
+      }
+    }
+
+    .browser-history-favicon {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.1rem;
+      height: 1.1rem;
+      color: var(--muted-color);
+
+      .material-symbols {
+        font-size: 1.05rem;
+      }
+
+      img {
+        position: absolute;
+        inset: 0;
+        display: block;
+        width: 1.1rem;
+        height: 1.1rem;
+        border-radius: 3px;
+        background: var(--card-background-color);
+        object-fit: contain;
+      }
+    }
+
+    .browser-history-text {
+      display: grid;
+      gap: 0.08rem;
+      min-width: 0;
+    }
+
+    .browser-history-title,
+    .browser-history-url {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      line-height: 1.2;
+    }
+
+    .browser-history-title {
+      font-size: 0.86rem;
+      font-weight: 600;
+    }
+
+    .browser-history-url {
+      color: color-mix(in srgb, var(--muted-color) 74%, var(--background-color));
+      font-size: 0.76rem;
+      font-weight: 400;
     }
 
     form.browser-address-bar {

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -79,18 +79,20 @@ div.browser-shell {
     }
 
     .browser-history-menu {
-      position: absolute;
-      top: calc(100% + 0.45rem);
-      left: 50%;
       width: min(34rem, calc(100vw - 1.5rem));
       max-height: min(28rem, calc(100vh - 6.5rem));
       overflow-y: auto;
-      transform: translateX(-8rem);
       padding: 0.45rem;
       border: 1px solid color-mix(in srgb, var(--primary) 14%, var(--pane-border-color));
       border-radius: 8px;
       background: color-mix(in srgb, var(--card-background-color) 98%, var(--background-color));
       box-shadow: 0 18px 42px color-mix(in srgb, var(--contrast) 18%, transparent);
+    }
+
+    .browser-history-menu-wrap {
+      display: flex;
+      justify-content: flex-start;
+      padding-left: 4.5rem;
     }
 
     .browser-history-empty {
@@ -279,10 +281,180 @@ div.browser-shell {
       min-width: 0;
     }
 
+    > .split-pane.browser-with-history {
+      width: 100%;
+      height: 100%;
+      min-width: 0;
+    }
+
     .browser-content,
+    .browser-history-secondary,
     .browser-webview-slot {
       min-width: 0;
       min-height: 0;
+    }
+
+    .browser-history-sidebar {
+      min-width: 260px;
+      max-width: min(520px, 70vw);
+      background: var(--background-color);
+      border-right: 1px solid var(--pane-border-color);
+    }
+
+    .browser-history-pane {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      min-height: 0;
+    }
+
+    .browser-history-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+      flex-shrink: 0;
+      min-height: 2.8rem;
+      padding: 0.45rem 0.65rem 0.45rem 0.85rem;
+      border-bottom: 1px solid color-mix(in srgb, var(--primary) 10%, var(--pane-border-color));
+      background: color-mix(in srgb, var(--card-background-color) 84%, var(--background-color));
+
+      h2 {
+        min-width: 0;
+        margin: 0;
+        overflow: hidden;
+        font-size: 0.94rem;
+        font-weight: 650;
+        line-height: 1.2;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      button.browser-action {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        width: 1.85rem;
+        height: 1.85rem;
+        padding: 0;
+        border: 0;
+        border-radius: 999px;
+        background: transparent;
+        color: var(--browser-tool-color);
+        box-shadow: none;
+
+        &:hover {
+          background: var(--browser-tool-hover-background);
+          color: var(--primary);
+        }
+      }
+    }
+
+    .browser-history-menu {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      padding: 0.45rem;
+    }
+
+    .browser-history-empty {
+      padding: 0.8rem 0.9rem;
+      color: var(--muted-color);
+      font-size: 0.86rem;
+      text-align: center;
+    }
+
+    .browser-history-groups,
+    .browser-history-list {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .browser-history-group + .browser-history-group {
+      margin-top: 0.35rem;
+      padding-top: 0.35rem;
+      border-top: 1px solid color-mix(in srgb, var(--primary) 9%, var(--pane-border-color));
+    }
+
+    .browser-history-entry {
+      button {
+        display: grid;
+        grid-template-columns: 1.3rem minmax(0, 1fr);
+        align-items: center;
+        gap: 0.55rem;
+        width: 100%;
+        min-height: 2.55rem;
+        margin: 0;
+        padding: 0.36rem 0.5rem;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--contrast);
+        box-shadow: none;
+        text-align: left;
+
+        &:hover,
+        &:focus {
+          background: var(--browser-tool-hover-background);
+          color: var(--contrast);
+        }
+      }
+
+      &.level-2 button {
+        padding-left: 1.75rem;
+      }
+    }
+
+    .browser-history-favicon {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.1rem;
+      height: 1.1rem;
+      color: var(--muted-color);
+
+      .material-symbols {
+        font-size: 1.05rem;
+      }
+
+      img {
+        position: absolute;
+        inset: 0;
+        display: block;
+        width: 1.1rem;
+        height: 1.1rem;
+        border-radius: 3px;
+        background: var(--card-background-color);
+        object-fit: contain;
+      }
+    }
+
+    .browser-history-text {
+      display: grid;
+      gap: 0.08rem;
+      min-width: 0;
+    }
+
+    .browser-history-title,
+    .browser-history-url {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      line-height: 1.2;
+    }
+
+    .browser-history-title {
+      font-size: 0.86rem;
+      font-weight: 600;
+    }
+
+    .browser-history-url {
+      color: color-mix(in srgb, var(--muted-color) 74%, var(--background-color));
+      font-size: 0.76rem;
+      font-weight: 400;
     }
 
     .browser-webview-slot {

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -185,7 +185,7 @@ div.browser-shell {
         width: 1.1rem;
         height: 1.1rem;
         border-radius: 3px;
-        background: var(--card-background-color);
+        background: #fff;
         object-fit: contain;
       }
     }
@@ -502,7 +502,7 @@ div.browser-shell {
         width: 1.1rem;
         height: 1.1rem;
         border-radius: 3px;
-        background: var(--card-background-color);
+        background: #fff;
         object-fit: contain;
       }
     }

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -143,6 +143,18 @@ div.browser-shell {
       &.level-2 button {
         padding-left: 1.75rem;
       }
+
+      &.current button {
+        border-left: 3px solid var(--primary);
+        background: color-mix(in srgb, var(--primary) 24%, var(--card-background-color));
+        color: var(--primary);
+        font-weight: 650;
+
+        .browser-history-title,
+        .browser-history-url {
+          color: var(--primary);
+        }
+      }
     }
 
     .browser-history-favicon {
@@ -412,6 +424,18 @@ div.browser-shell {
 
       &.level-2 button {
         padding-left: 1.75rem;
+      }
+
+      &.current button {
+        border-left: 3px solid var(--primary);
+        background: color-mix(in srgb, var(--primary) 24%, var(--card-background-color));
+        color: var(--primary);
+        font-weight: 650;
+
+        .browser-history-title,
+        .browser-history-url {
+          color: var(--primary);
+        }
       }
     }
 

--- a/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
+++ b/cotoami_desktop/ui/assets/css/app/_browser-shell.scss
@@ -117,7 +117,9 @@ div.browser-shell {
     }
 
     .browser-history-entry {
-      button {
+      position: relative;
+
+      > button.browser-history-open {
         display: grid;
         grid-template-columns: 1.3rem minmax(0, 1fr);
         align-items: center;
@@ -140,11 +142,11 @@ div.browser-shell {
         }
       }
 
-      &.level-2 button {
+      &.level-2 > button.browser-history-open {
         padding-left: 1.75rem;
       }
 
-      &.current button {
+      &.current > button.browser-history-open {
         border-left: 3px solid var(--primary);
         background: color-mix(in srgb, var(--primary) 24%, var(--card-background-color));
         color: var(--primary);
@@ -154,6 +156,12 @@ div.browser-shell {
         .browser-history-url {
           color: var(--primary);
         }
+      }
+
+      &:hover .browser-history-delete,
+      &:focus-within .browser-history-delete {
+        opacity: 1;
+        pointer-events: auto;
       }
     }
 
@@ -186,6 +194,33 @@ div.browser-shell {
       display: grid;
       gap: 0.08rem;
       min-width: 0;
+    }
+
+    button.browser-history-delete {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.55rem;
+      height: 1.55rem;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      border-radius: 999px;
+      background: transparent;
+      color: var(--muted-color);
+      box-shadow: none;
+      opacity: 0;
+      pointer-events: none;
+
+      .material-symbols {
+        font-size: 1rem;
+      }
+
+      &:hover,
+      &:focus {
+        background: color-mix(in srgb, var(--del-color) 14%, transparent);
+        color: var(--del-color);
+      }
     }
 
     .browser-history-title,
@@ -399,7 +434,9 @@ div.browser-shell {
     }
 
     .browser-history-entry {
-      button {
+      position: relative;
+
+      > button.browser-history-open {
         display: grid;
         grid-template-columns: 1.3rem minmax(0, 1fr);
         align-items: center;
@@ -422,11 +459,11 @@ div.browser-shell {
         }
       }
 
-      &.level-2 button {
+      &.level-2 > button.browser-history-open {
         padding-left: 1.75rem;
       }
 
-      &.current button {
+      &.current > button.browser-history-open {
         border-left: 3px solid var(--primary);
         background: color-mix(in srgb, var(--primary) 24%, var(--card-background-color));
         color: var(--primary);
@@ -436,6 +473,12 @@ div.browser-shell {
         .browser-history-url {
           color: var(--primary);
         }
+      }
+
+      &:hover .browser-history-delete,
+      &:focus-within .browser-history-delete {
+        opacity: 1;
+        pointer-events: auto;
       }
     }
 
@@ -468,6 +511,37 @@ div.browser-shell {
       display: grid;
       gap: 0.08rem;
       min-width: 0;
+    }
+
+    button.browser-history-delete {
+      position: absolute;
+      top: 50%;
+      right: 0.4rem;
+      transform: translateY(-50%);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.55rem;
+      height: 1.55rem;
+      margin: 0;
+      padding: 0;
+      border: 0;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--card-background-color) 92%, transparent);
+      color: var(--muted-color);
+      box-shadow: none;
+      opacity: 0;
+      pointer-events: none;
+
+      .material-symbols {
+        font-size: 1rem;
+      }
+
+      &:hover,
+      &:focus {
+        background: color-mix(in srgb, var(--del-color) 14%, transparent);
+        color: var(--del-color);
+      }
     }
 
     .browser-history-title,

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
@@ -52,6 +52,107 @@ object App {
       focusedCotonomaId: Option[Id[Cotonoma]]
   )
 
+  case class BrowserHistoryEntry(
+      url: String,
+      title: Option[String],
+      origin: String,
+      host: String,
+      path: String,
+      faviconUrl: String,
+      firstVisited: Int,
+      lastVisited: Int
+  ) {
+    def label: String =
+      title.map(_.trim).filter(_.nonEmpty).getOrElse(host)
+  }
+
+  case class BrowserHistoryGroup(
+      parent: BrowserHistoryEntry,
+      children: Seq[BrowserHistoryEntry],
+      lastVisited: Int
+  )
+
+  case class BrowserHistory(
+      entries: Seq[BrowserHistoryEntry] = Seq.empty,
+      nextVisit: Int = 1
+  ) {
+    def remember(url: String, title: Option[String]): BrowserHistory =
+      BrowserHistory.parse(url) match {
+        case Some(parsed) =>
+          val nextEntries =
+            entries.indexWhere(_.url == parsed.url) match {
+              case -1 =>
+                entries :+ BrowserHistoryEntry(
+                  url = parsed.url,
+                  title = title,
+                  origin = parsed.origin,
+                  host = parsed.host,
+                  path = parsed.path,
+                  faviconUrl = s"${parsed.origin}/favicon.ico",
+                  firstVisited = nextVisit,
+                  lastVisited = nextVisit
+                )
+              case index =>
+                entries.updated(
+                  index,
+                  entries(index).copy(
+                    title = title.orElse(entries(index).title),
+                    lastVisited = nextVisit
+                  )
+                )
+            }
+          copy(entries = nextEntries, nextVisit = nextVisit + 1)
+        case None => this
+      }
+
+    def groups: Seq[BrowserHistoryGroup] =
+      entries
+        .groupBy(_.origin)
+        .values
+        .map(entriesInOrigin => {
+          val parent = entriesInOrigin.minBy(_.firstVisited)
+          val children = entriesInOrigin
+            .filterNot(_.url == parent.url)
+            .sortBy(entry => -entry.lastVisited)
+            .toSeq
+          BrowserHistoryGroup(
+            parent,
+            children,
+            entriesInOrigin.map(_.lastVisited).max
+          )
+        })
+        .toSeq
+        .sortBy(group => -group.lastVisited)
+  }
+
+  object BrowserHistory {
+    private case class ParsedUrl(
+        url: String,
+        origin: String,
+        host: String,
+        path: String
+    )
+
+    private def parse(url: String): Option[ParsedUrl] =
+      try {
+        val parsed = new URL(url)
+        Option
+          .when(parsed.protocol == "http:" || parsed.protocol == "https:") {
+            val path = Seq(parsed.pathname, parsed.search, parsed.hash)
+              .filter(_.nonEmpty)
+              .mkString
+            ParsedUrl(
+              url = parsed.href,
+              origin = parsed.origin,
+              host = parsed.host,
+              path = if (path.nonEmpty) path else "/"
+            )
+          }
+      } catch {
+        case _: Throwable => None
+      }
+  }
+
   @js.native
   trait BrowserDatabaseFocusJson extends js.Object {
     val databaseFolder: String = js.native
@@ -71,6 +172,7 @@ object App {
       initialTheme: Option[String],
       app: CotoamiModel,
       cotonomaSelect: CotonomaSelect.Model,
+      history: BrowserHistory,
       pendingFocus: Option[BrowserDatabaseFocus],
       currentFocus: Option[BrowserDatabaseFocus]
   )
@@ -205,6 +307,7 @@ object App {
         initialTheme = props.theme,
         app = app,
         cotonomaSelect = CotonomaSelect.Model(),
+        history = BrowserHistory(),
         pendingFocus = props.initialFocus,
         currentFocus = None
       ),
@@ -220,8 +323,18 @@ object App {
 
   private def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match {
-      case Msg.BrowserStateChanged(url, title) =>
-        (model.copy(url = url, title = title), Cmd.none)
+      case Msg.BrowserStateChanged(url, title) => {
+        val historyTitle =
+          if (url != model.url && title == model.title) None else title
+        (
+          model.copy(
+            url = url,
+            title = title,
+            history = model.history.remember(url, historyTitle)
+          ),
+          Cmd.none
+        )
+      }
 
       case Msg.SystemInfoFetched(Right(info)) =>
         (model.copy(app = model.app.setSystemInfo(info)), Cmd.none)

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
@@ -325,7 +325,7 @@ object App {
     msg match {
       case Msg.BrowserStateChanged(url, title) => {
         val historyTitle =
-          if (url != model.url && title == model.title) None else title
+          if (url != model.url) None else title
         (
           model.copy(
             url = url,

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
@@ -52,7 +52,7 @@ object App {
       focusedCotonomaId: Option[Id[Cotonoma]]
   )
 
-  case class BrowserHistoryEntry(
+  case class BrowserTrailEntry(
       url: String,
       title: Option[String],
       origin: String,
@@ -66,23 +66,23 @@ object App {
       title.map(_.trim).filter(_.nonEmpty).getOrElse(host)
   }
 
-  case class BrowserHistoryGroup(
-      parent: BrowserHistoryEntry,
-      children: Seq[BrowserHistoryEntry],
+  case class BrowserTrailGroup(
+      parent: BrowserTrailEntry,
+      children: Seq[BrowserTrailEntry],
       lastVisited: Int
   )
 
-  case class BrowserHistory(
-      entries: Seq[BrowserHistoryEntry] = Seq.empty,
+  case class BrowserTrail(
+      entries: Seq[BrowserTrailEntry] = Seq.empty,
       nextVisit: Int = 1
   ) {
-    def remember(url: String, title: Option[String]): BrowserHistory =
-      BrowserHistory.parse(url) match {
+    def remember(url: String, title: Option[String]): BrowserTrail =
+      BrowserTrail.parse(url) match {
         case Some(parsed) =>
           val nextEntries =
             entries.indexWhere(_.url == parsed.url) match {
               case -1 =>
-                entries :+ BrowserHistoryEntry(
+                entries :+ BrowserTrailEntry(
                   url = parsed.url,
                   title = title,
                   origin = parsed.origin,
@@ -105,17 +105,18 @@ object App {
         case None => this
       }
 
-    def groups: Seq[BrowserHistoryGroup] =
-      entries.map(_.origin).distinct.flatMap(origin =>
+    def groups: Seq[BrowserTrailGroup] =
+      entries.map(_.origin).distinct.reverse.flatMap(origin =>
         entries.filter(_.origin == origin) match {
           case Seq() => None
           case entriesInOrigin =>
           val parent = entriesInOrigin.minBy(_.firstVisited)
           val children = entriesInOrigin
             .filterNot(_.url == parent.url)
+            .reverse
             .toSeq
           Some(
-            BrowserHistoryGroup(
+            BrowserTrailGroup(
               parent,
               children,
               entriesInOrigin.map(_.lastVisited).max
@@ -124,19 +125,19 @@ object App {
         }
       )
 
-    def deleteEntry(entry: BrowserHistoryEntry, level: Int): BrowserHistory =
+    def deleteEntry(entry: BrowserTrailEntry, level: Int): BrowserTrail =
       if (level == 1)
         copy(entries = entries.filterNot(_.origin == entry.origin))
       else
         copy(entries = entries.filterNot(_.url == entry.url))
 
-    def entryForUrl(url: String): Option[BrowserHistoryEntry] =
-      BrowserHistory.parse(url).flatMap(parsed =>
+    def entryForUrl(url: String): Option[BrowserTrailEntry] =
+      BrowserTrail.parse(url).flatMap(parsed =>
         entries.find(_.url == parsed.url)
       )
   }
 
-  object BrowserHistory {
+  object BrowserTrail {
     private case class ParsedUrl(
         url: String,
         origin: String,
@@ -183,7 +184,7 @@ object App {
       initialTheme: Option[String],
       app: CotoamiModel,
       cotonomaSelect: CotonomaSelect.Model,
-      history: BrowserHistory,
+      trail: BrowserTrail,
       pendingFocus: Option[BrowserDatabaseFocus],
       currentFocus: Option[BrowserDatabaseFocus]
   )
@@ -193,8 +194,8 @@ object App {
   object Msg {
     case class BrowserStateChanged(url: String, title: Option[String])
         extends Msg
-    case class BrowserHistoryEntryDeleted(
-        entry: BrowserHistoryEntry,
+    case class BrowserTrailEntryDeleted(
+        entry: BrowserTrailEntry,
         level: Int
     ) extends Msg
     case class SystemInfoFetched(result: Either[Unit, SystemInfoJson])
@@ -322,7 +323,7 @@ object App {
         initialTheme = props.theme,
         app = app,
         cotonomaSelect = CotonomaSelect.Model(),
-        history = BrowserHistory(),
+        trail = BrowserTrail(),
         pendingFocus = props.initialFocus,
         currentFocus = None
       ),
@@ -343,14 +344,14 @@ object App {
           model.copy(
             url = url,
             title = title,
-            history = model.history.remember(url, title)
+            trail = model.trail.remember(url, title)
           ),
           Cmd.none
         )
 
-      case Msg.BrowserHistoryEntryDeleted(entry, level) =>
+      case Msg.BrowserTrailEntryDeleted(entry, level) =>
         (
-          model.copy(history = model.history.deleteEntry(entry, level)),
+          model.copy(trail = model.trail.deleteEntry(entry, level)),
           Cmd.none
         )
 
@@ -619,8 +620,8 @@ object App {
           ),
         onStateChange = (url, title) =>
           dispatch(Msg.BrowserStateChanged(url, title)),
-        onHistoryEntryDelete = (entry, level) =>
-          dispatch(Msg.BrowserHistoryEntryDeleted(entry, level))
+        onTrailEntryDelete = (entry, level) =>
+          dispatch(Msg.BrowserTrailEntryDeleted(entry, level))
       )
     )
   }

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
@@ -323,18 +323,15 @@ object App {
 
   private def update(msg: Msg, model: Model): (Model, Cmd[Msg]) =
     msg match {
-      case Msg.BrowserStateChanged(url, title) => {
-        val historyTitle =
-          if (url != model.url) None else title
+      case Msg.BrowserStateChanged(url, title) =>
         (
           model.copy(
             url = url,
             title = title,
-            history = model.history.remember(url, historyTitle)
+            history = model.history.remember(url, title)
           ),
           Cmd.none
         )
-      }
 
       case Msg.SystemInfoFetched(Right(info)) =>
         (model.copy(app = model.app.setSystemInfo(info)), Cmd.none)

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
@@ -106,23 +106,23 @@ object App {
       }
 
     def groups: Seq[BrowserHistoryGroup] =
-      entries
-        .groupBy(_.origin)
-        .values
-        .map(entriesInOrigin => {
+      entries.map(_.origin).distinct.flatMap(origin =>
+        entries.filter(_.origin == origin) match {
+          case Seq() => None
+          case entriesInOrigin =>
           val parent = entriesInOrigin.minBy(_.firstVisited)
           val children = entriesInOrigin
             .filterNot(_.url == parent.url)
-            .sortBy(entry => -entry.lastVisited)
             .toSeq
-          BrowserHistoryGroup(
-            parent,
-            children,
-            entriesInOrigin.map(_.lastVisited).max
+          Some(
+            BrowserHistoryGroup(
+              parent,
+              children,
+              entriesInOrigin.map(_.lastVisited).max
+            )
           )
-        })
-        .toSeq
-        .sortBy(group => -group.lastVisited)
+        }
+      )
   }
 
   object BrowserHistory {

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/App.scala
@@ -123,6 +123,17 @@ object App {
           )
         }
       )
+
+    def deleteEntry(entry: BrowserHistoryEntry, level: Int): BrowserHistory =
+      if (level == 1)
+        copy(entries = entries.filterNot(_.origin == entry.origin))
+      else
+        copy(entries = entries.filterNot(_.url == entry.url))
+
+    def entryForUrl(url: String): Option[BrowserHistoryEntry] =
+      BrowserHistory.parse(url).flatMap(parsed =>
+        entries.find(_.url == parsed.url)
+      )
   }
 
   object BrowserHistory {
@@ -182,6 +193,10 @@ object App {
   object Msg {
     case class BrowserStateChanged(url: String, title: Option[String])
         extends Msg
+    case class BrowserHistoryEntryDeleted(
+        entry: BrowserHistoryEntry,
+        level: Int
+    ) extends Msg
     case class SystemInfoFetched(result: Either[Unit, SystemInfoJson])
         extends Msg
     case class UiStateRestored(uiState: Option[UiState]) extends Msg
@@ -330,6 +345,12 @@ object App {
             title = title,
             history = model.history.remember(url, title)
           ),
+          Cmd.none
+        )
+
+      case Msg.BrowserHistoryEntryDeleted(entry, level) =>
+        (
+          model.copy(history = model.history.deleteEntry(entry, level)),
           Cmd.none
         )
 
@@ -597,7 +618,9 @@ object App {
             Msg.AppMsg(AppMsg.ResizePane(BrowserShell.TimelinePaneName, width))
           ),
         onStateChange = (url, title) =>
-          dispatch(Msg.BrowserStateChanged(url, title))
+          dispatch(Msg.BrowserStateChanged(url, title)),
+        onHistoryEntryDelete = (entry, level) =>
+          dispatch(Msg.BrowserHistoryEntryDeleted(entry, level))
       )
     )
   }

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -131,7 +131,8 @@ object BrowserShell {
       setTitle: Option[String] => Unit,
       setLoading: Boolean => Unit,
       editingRef: ReactRef[Boolean],
-      currentWindowTitleRef: ReactRef[String]
+      currentWindowTitleRef: ReactRef[String],
+      onStateChange: (String, Option[String]) => Unit
   ): Unit = {
     val title = optionString(state.title)
     setActualUrl(state.url)
@@ -145,6 +146,7 @@ object BrowserShell {
       tauri.window.getCurrentWindow().setTitle(nextWindowTitle)
       ()
     }
+    onStateChange(state.url, title)
   }
 
   val component = FunctionalComponent[Props] { props =>
@@ -259,7 +261,8 @@ object BrowserShell {
                 setTitle,
                 setLoading,
                 editingRef,
-                windowTitleRef
+                windowTitleRef,
+                props.onStateChange
               )
               if (pendingResizeRef.current) {
                 pendingResizeRef.current = false
@@ -304,7 +307,8 @@ object BrowserShell {
               setTitle,
               setLoading,
               editingRef,
-              windowTitleRef
+              windowTitleRef,
+              props.onStateChange
             )
             resizeBrowserView()
           case Failure(throwable) =>
@@ -328,7 +332,8 @@ object BrowserShell {
               setTitle,
               setLoading,
               editingRef,
-              windowTitleRef
+              windowTitleRef,
+              props.onStateChange
             )
           case Failure(throwable) =>
             handleFailure("Browser command failed")(throwable)
@@ -347,7 +352,6 @@ object BrowserShell {
       }
 
     def navigateToHistory(url: String): Unit = {
-      setHistoryOpen(false)
       setActualUrl(url)
       setDraftUrl(url)
       setLoading(true)
@@ -421,14 +425,6 @@ object BrowserShell {
 
     useEffect(
       () => {
-        props.onStateChange(actualUrl, pageTitle)
-        () => ()
-      },
-      Seq(actualUrl, pageTitle.orNull)
-    )
-
-    useEffect(
-      () => {
         val toolbar = toolbarRef.current
         if (toolbar == null) () => ()
         else {
@@ -497,7 +493,8 @@ object BrowserShell {
                     setTitle,
                     setLoading,
                     editingRef,
-                    windowTitleRef
+                    windowTitleRef,
+                    props.onStateChange
                   )
                 })
           )

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -29,7 +29,7 @@ object BrowserShell {
 
   final val TimelinePaneName = "BrowserTimeline"
   final val DefaultTimelineWidth = 380
-  private val DefaultHistoryWidth = 340
+  private val DefaultTrailWidth = 340
 
   private val ToolbarHeight = 54.0
   private val ResizeSettleMs = 50.0
@@ -60,7 +60,7 @@ object BrowserShell {
       onTimelineOpenChange: Boolean => Unit,
       onTimelineWidthChange: Int => Unit,
       onStateChange: (String, Option[String]) => Unit,
-      onHistoryEntryDelete: (App.BrowserHistoryEntry, Int) => Unit
+      onTrailEntryDelete: (App.BrowserTrailEntry, Int) => Unit
   )
 
   private def normalizeUrl(input: String): Option[String] = {
@@ -156,7 +156,7 @@ object BrowserShell {
     val (pageTitle, setTitleRaw) = useState(props.model.title)
     val (loading, setLoadingRaw) = useState(true)
     val (error, setErrorRaw) = useState(Option.empty[String])
-    val (historyOpen, setHistoryOpenRaw) = useState(false)
+    val (trailOpen, setTrailOpenRaw) = useState(false)
     val browserAttachedRef = useRef(false)
     val resizeInFlightRef = useRef(false)
     val pendingResizeRef = useRef(false)
@@ -182,8 +182,8 @@ object BrowserShell {
     def setError(value: Option[String]): Unit =
       setErrorRaw(_ => value)
 
-    def setHistoryOpen(value: Boolean): Unit =
-      setHistoryOpenRaw(_ => value)
+    def setTrailOpen(value: Boolean): Unit =
+      setTrailOpenRaw(_ => value)
 
     def setToolbarHeight(height: Double): Unit =
       setToolbarHeightRaw(current =>
@@ -352,7 +352,7 @@ object BrowserShell {
           setError(Some(props.text.BrowserShell_invalidUrl))
       }
 
-    def navigateToHistory(url: String): Unit = {
+    def navigateToTrail(url: String): Unit = {
       setActualUrl(url)
       setDraftUrl(url)
       setLoading(true)
@@ -360,25 +360,25 @@ object BrowserShell {
       invokeBrowserCommand("browser_navigate", jso(url = url))
     }
 
-    def historyEntry(
-        entry: App.BrowserHistoryEntry,
+    def trailEntry(
+        entry: App.BrowserTrailEntry,
         level: Int,
         displayUrl: String,
         entryKey: Option[String] = None
     ): ReactElement = {
-      val currentEntry = props.model.history.entryForUrl(actualUrl)
+      val currentEntry = props.model.trail.entryForUrl(actualUrl)
       val current = currentEntry.exists(_.url == entry.url)
       val canDelete =
         !current && !(level == 1 && currentEntry.exists(_.origin == entry.origin))
       val entryClass = optionalClasses(
         Seq(
-          (s"browser-history-entry level-${level}", true),
+          (s"browser-trail-entry level-${level}", true),
           ("current", current)
         )
       )
       val deleteButton = Option.when(canDelete) {
         button(
-          className := "browser-history-delete",
+          className := "browser-trail-delete",
           `type` := "button",
           title := "Delete",
           onMouseDown := (e => {
@@ -387,7 +387,7 @@ object BrowserShell {
           }),
           onClick := (e => {
             e.stopPropagation()
-            props.onHistoryEntryDelete(entry, level)
+            props.onTrailEntryDelete(entry, level)
           })
         )(
           materialSymbol("delete")
@@ -396,13 +396,13 @@ object BrowserShell {
       val content =
         Seq(
           button(
-            className := "browser-history-open",
+            className := "browser-trail-open",
             `type` := "button",
             title := entry.url,
             onMouseDown := (e => e.preventDefault()),
-            onClick := (_ => navigateToHistory(entry.url))
+            onClick := (_ => navigateToTrail(entry.url))
           )(
-            span(className := "browser-history-favicon")(
+            span(className := "browser-trail-favicon")(
               materialSymbol("language"),
               img(
                 alt := "",
@@ -415,9 +415,9 @@ object BrowserShell {
                 )
               )
             ),
-            span(className := "browser-history-text")(
-              span(className := "browser-history-title")(entry.label),
-              span(className := "browser-history-url")(displayUrl)
+            span(className := "browser-trail-text")(
+              span(className := "browser-trail-title")(entry.label),
+              span(className := "browser-trail-url")(displayUrl)
             )
           )
         ) ++ deleteButton.toSeq
@@ -431,21 +431,21 @@ object BrowserShell {
       }
     }
 
-    def historyDropdown: ReactElement = {
-      val groups = props.model.history.groups
-      div(className := "browser-history-menu")(
+    def trailList: ReactElement = {
+      val groups = props.model.trail.groups
+      div(className := "browser-trail-menu")(
         if (groups.isEmpty)
-          div(className := "browser-history-empty")(
-            props.text.BrowserShell_historyEmpty
+          div(className := "browser-trail-empty")(
+            props.text.BrowserShell_trailEmpty
           )
         else
-          ul(className := "browser-history-groups")(
+          ul(className := "browser-trail-groups")(
             groups.map(group =>
-              li(className := "browser-history-group", key := group.parent.origin)(
-                ul(className := "browser-history-list")(
-                  (Seq(historyEntry(group.parent, 1, group.parent.url)) ++
+              li(className := "browser-trail-group", key := group.parent.origin)(
+                ul(className := "browser-trail-list")(
+                  (Seq(trailEntry(group.parent, 1, group.parent.url)) ++
                     group.children.map(child =>
-                      historyEntry(child, 2, child.path, Some(child.url))
+                      trailEntry(child, 2, child.path, Some(child.url))
                     ))*
                 )
               )
@@ -574,7 +574,7 @@ object BrowserShell {
       Seq(
         props.contentLabel,
         toolbarHeight,
-        historyOpen,
+        trailOpen,
         props.timelineOpened,
         props.timelineWidth
       )
@@ -610,7 +610,7 @@ object BrowserShell {
       },
       Seq(
         props.contentLabel,
-        historyOpen,
+        trailOpen,
         props.timelineOpened,
         props.timelineWidth
       )
@@ -670,36 +670,36 @@ object BrowserShell {
         ).withKey(s"${props.timelineOpened}-${props.timelineWidth}")
       ).getOrElse(browserWebviewSlot)
 
-    val historyPane =
-      div(className := "browser-history-pane")(
-        header(className := "browser-history-header")(
-          h2()(props.text.BrowserShell_history),
+    val trailPane =
+      div(className := "browser-trail-pane")(
+        header(className := "browser-trail-header")(
+          h2()(props.text.BrowserShell_trail),
           button(
             className := "browser-action",
             `type` := "button",
             title := "Close",
-            onClick := (_ => setHistoryOpen(false))
+            onClick := (_ => setTrailOpen(false))
           )(materialSymbol("close"))
         ),
-        historyDropdown
+        trailList
       )
 
     val browserSurfaceContent =
-      if (historyOpen)
+      if (trailOpen)
         SplitPane(
           vertical = true,
-          initialPrimarySize = DefaultHistoryWidth,
+          initialPrimarySize = DefaultTrailWidth,
           resizable = true,
-          className = Some("browser-with-history"),
+          className = Some("browser-with-trail"),
           onResizing = Some(_ => resizeBrowserViewAfterLayout()),
           onResizeEnd = Some(() => resizeBrowserView()),
           primary = SplitPane.Primary.Props(
-            className = Some("browser-history-sidebar")
-          )(historyPane),
+            className = Some("browser-trail-sidebar")
+          )(trailPane),
           secondary = SplitPane.Secondary.Props(
-            className = Some("browser-history-secondary")
+            className = Some("browser-trail-secondary")
           )(browserContent)
-        ).withKey("history-open")
+        ).withKey("trail-open")
       else
         browserContent
 
@@ -737,14 +737,14 @@ object BrowserShell {
               )
             ),
             div(
-              className := "browser-history-tool"
+              className := "browser-trail-tool"
             )(
               button(
                 className := "browser-action",
                 `type` := "button",
-                title := props.text.BrowserShell_history,
-                onClick := (_ => setHistoryOpen(!historyOpen))
-              )(materialSymbol("history"))
+                title := props.text.BrowserShell_trail,
+                onClick := (_ => setTrailOpen(!trailOpen))
+              )(materialSymbol("route"))
             )
           ),
           form(

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -29,6 +29,7 @@ object BrowserShell {
 
   final val TimelinePaneName = "BrowserTimeline"
   final val DefaultTimelineWidth = 380
+  private val DefaultHistoryWidth = 340
 
   private val ToolbarHeight = 54.0
   private val ResizeSettleMs = 50.0
@@ -540,6 +541,7 @@ object BrowserShell {
       Seq(
         props.contentLabel,
         toolbarHeight,
+        historyOpen,
         props.timelineOpened,
         props.timelineWidth
       )
@@ -587,7 +589,7 @@ object BrowserShell {
         )
       )
 
-    val browserSurfaceContent =
+    val browserContent =
       props.timeline.map(timeline =>
         SplitPane(
           vertical = true,
@@ -629,6 +631,38 @@ object BrowserShell {
         ).withKey(s"${props.timelineOpened}-${props.timelineWidth}")
       ).getOrElse(browserWebviewSlot)
 
+    val historyPane =
+      div(className := "browser-history-pane")(
+        header(className := "browser-history-header")(
+          h2()(props.text.BrowserShell_history),
+          button(
+            className := "browser-action",
+            `type` := "button",
+            title := "Close",
+            onClick := (_ => setHistoryOpen(false))
+          )(materialSymbol("close"))
+        ),
+        historyDropdown
+      )
+
+    val browserSurfaceContent =
+      if (historyOpen)
+        SplitPane(
+          vertical = true,
+          initialPrimarySize = DefaultHistoryWidth,
+          resizable = true,
+          className = Some("browser-with-history"),
+          onResizeEnd = Some(() => resizeBrowserView()),
+          primary = SplitPane.Primary.Props(
+            className = Some("browser-history-sidebar")
+          )(historyPane),
+          secondary = SplitPane.Secondary.Props(
+            className = Some("browser-history-secondary")
+          )(browserContent)
+        ).withKey("history-open")
+      else
+        browserContent
+
     div(className := "browser-shell")(
       header(className := "browser-toolbar", ref := toolbarRef)(
         div(className := "browser-toolbar-main")(
@@ -663,17 +697,14 @@ object BrowserShell {
               )
             ),
             div(
-              className := "browser-history-tool",
-              onMouseEnter := (_ => setHistoryOpen(true)),
-              onMouseLeave := (_ => setHistoryOpen(false))
+              className := "browser-history-tool"
             )(
               button(
                 className := "browser-action",
                 `type` := "button",
                 title := props.text.BrowserShell_history,
-                onFocus := (_ => setHistoryOpen(true))
-              )(materialSymbol("history")),
-              Option.when(historyOpen)(historyDropdown)
+                onClick := (_ => setHistoryOpen(!historyOpen))
+              )(materialSymbol("history"))
             )
           ),
           form(

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -90,6 +90,13 @@ object BrowserShell {
     Ipv4AddressPattern.matches(trimmed)
   }
 
+  private def isSecureUrl(url: String): Boolean =
+    try {
+      new dom.URL(url).protocol == "https:"
+    } catch {
+      case _: Throwable => false
+    }
+
   private def resolveAddressBarInput(input: String): Option[String] = {
     val trimmed = input.trim
     if (trimmed.isEmpty()) None
@@ -616,7 +623,8 @@ object BrowserShell {
       )
     )
 
-    val secure = actualUrl.startsWith("https://")
+    val displayedUrl = if (editingRef.current) draftUrl else actualUrl
+    val secure = isSecureUrl(displayedUrl)
     val addressIcon = if (secure) "lock" else "language"
 
     val browserWebviewSlot =

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -153,7 +153,7 @@ object BrowserShell {
   val component = FunctionalComponent[Props] { props =>
     val (actualUrl, setActualUrlRaw) = useState(props.initialUrl)
     val (draftUrl, setDraftUrlRaw) = useState(props.initialUrl)
-    val (pageTitle, setTitleRaw) = useState(props.model.title)
+    val (_, setTitleRaw) = useState(props.model.title)
     val (loading, setLoadingRaw) = useState(true)
     val (error, setErrorRaw) = useState(Option.empty[String])
     val (trailOpen, setTrailOpenRaw) = useState(false)

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -740,7 +740,12 @@ object BrowserShell {
               className := "browser-trail-tool"
             )(
               button(
-                className := "browser-action",
+                className := optionalClasses(
+                  Seq(
+                    ("browser-action", true),
+                    ("active", trailOpen)
+                  )
+                ),
                 `type` := "button",
                 title := props.text.BrowserShell_trail,
                 onClick := (_ => setTrailOpen(!trailOpen))

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -152,6 +152,7 @@ object BrowserShell {
     val (pageTitle, setTitleRaw) = useState(props.model.title)
     val (loading, setLoadingRaw) = useState(true)
     val (error, setErrorRaw) = useState(Option.empty[String])
+    val (historyOpen, setHistoryOpenRaw) = useState(false)
     val browserAttachedRef = useRef(false)
     val resizeInFlightRef = useRef(false)
     val pendingResizeRef = useRef(false)
@@ -176,6 +177,9 @@ object BrowserShell {
 
     def setError(value: Option[String]): Unit =
       setErrorRaw(_ => value)
+
+    def setHistoryOpen(value: Boolean): Unit =
+      setHistoryOpenRaw(_ => value)
 
     def setToolbarHeight(height: Double): Unit =
       setToolbarHeightRaw(current =>
@@ -335,6 +339,79 @@ object BrowserShell {
         case None =>
           setError(Some(props.text.BrowserShell_invalidUrl))
       }
+
+    def navigateToHistory(url: String): Unit = {
+      setHistoryOpen(false)
+      setActualUrl(url)
+      setDraftUrl(url)
+      setLoading(true)
+      setError(None)
+      invokeBrowserCommand("browser_navigate", jso(url = url))
+    }
+
+    def historyEntry(
+        entry: App.BrowserHistoryEntry,
+        level: Int,
+        displayUrl: String,
+        entryKey: Option[String] = None
+    ): ReactElement = {
+      val content =
+        button(
+          `type` := "button",
+          title := entry.url,
+          onMouseDown := (e => e.preventDefault()),
+          onClick := (_ => navigateToHistory(entry.url))
+        )(
+          span(className := "browser-history-favicon")(
+            materialSymbol("language"),
+            img(
+              alt := "",
+              src := entry.faviconUrl,
+              onError := (e =>
+                e.currentTarget
+                  .asInstanceOf[dom.HTMLImageElement]
+                  .style
+                  .display = "none"
+              )
+            )
+          ),
+          span(className := "browser-history-text")(
+            span(className := "browser-history-title")(entry.label),
+            span(className := "browser-history-url")(displayUrl)
+          )
+        )
+      entryKey match {
+        case Some(value) =>
+          li(className := s"browser-history-entry level-${level}", key := value)(
+            content
+          )
+        case None =>
+          li(className := s"browser-history-entry level-${level}")(content)
+      }
+    }
+
+    def historyDropdown: ReactElement = {
+      val groups = props.model.history.groups
+      div(className := "browser-history-menu")(
+        if (groups.isEmpty)
+          div(className := "browser-history-empty")(
+            props.text.BrowserShell_historyEmpty
+          )
+        else
+          ul(className := "browser-history-groups")(
+            groups.map(group =>
+              li(className := "browser-history-group", key := group.parent.origin)(
+                ul(className := "browser-history-list")(
+                  (Seq(historyEntry(group.parent, 1, group.parent.url)) ++
+                    group.children.map(child =>
+                      historyEntry(child, 2, child.path, Some(child.url))
+                    ))*
+                )
+              )
+            )*
+          )
+      )
+    }
 
     useEffect(
       () => {
@@ -584,6 +661,19 @@ object BrowserShell {
                 if (loading) "progress_activity" else "refresh",
                 if (loading) "loading" else ""
               )
+            ),
+            div(
+              className := "browser-history-tool",
+              onMouseEnter := (_ => setHistoryOpen(true)),
+              onMouseLeave := (_ => setHistoryOpen(false))
+            )(
+              button(
+                className := "browser-action",
+                `type` := "button",
+                title := props.text.BrowserShell_history,
+                onFocus := (_ => setHistoryOpen(true))
+              )(materialSymbol("history")),
+              Option.when(historyOpen)(historyDropdown)
             )
           ),
           form(

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -365,6 +365,13 @@ object BrowserShell {
         displayUrl: String,
         entryKey: Option[String] = None
     ): ReactElement = {
+      val current = entry.url == actualUrl
+      val entryClass = optionalClasses(
+        Seq(
+          (s"browser-history-entry level-${level}", true),
+          ("current", current)
+        )
+      )
       val content =
         button(
           `type` := "button",
@@ -392,11 +399,11 @@ object BrowserShell {
         )
       entryKey match {
         case Some(value) =>
-          li(className := s"browser-history-entry level-${level}", key := value)(
+          li(className := entryClass, key := value)(
             content
           )
         case None =>
-          li(className := s"browser-history-entry level-${level}")(content)
+          li(className := entryClass)(content)
       }
     }
 

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -278,6 +278,11 @@ object BrowserShell {
         flushBrowserResize()
       }
 
+    def resizeBrowserViewAfterLayout(): Unit =
+      dom.window.requestAnimationFrame(_ =>
+        dom.window.requestAnimationFrame(_ => resizeBrowserView())
+      )
+
     def attachBrowserView(): Unit =
       tauri.core
         .invoke[BrowserViewStateJson](
@@ -535,7 +540,7 @@ object BrowserShell {
 
     useEffect(
       () => {
-        resizeBrowserView()
+        resizeBrowserViewAfterLayout()
         () => ()
       },
       Seq(
@@ -575,7 +580,12 @@ object BrowserShell {
           }
         }
       },
-      Seq(props.contentLabel, props.timelineOpened, props.timelineWidth)
+      Seq(
+        props.contentLabel,
+        historyOpen,
+        props.timelineOpened,
+        props.timelineWidth
+      )
     )
 
     val secure = actualUrl.startsWith("https://")
@@ -597,6 +607,7 @@ object BrowserShell {
           initialPrimarySize = props.timelineWidth,
           resizable = props.timelineOpened,
           className = Some("browser-main"),
+          onResizing = Some(_ => resizeBrowserViewAfterLayout()),
           onResizeEnd = Some(() => resizeBrowserView()),
           onPrimarySizeChanged = Some(props.onTimelineWidthChange),
           primary = SplitPane.Primary.Props(
@@ -652,6 +663,7 @@ object BrowserShell {
           initialPrimarySize = DefaultHistoryWidth,
           resizable = true,
           className = Some("browser-with-history"),
+          onResizing = Some(_ => resizeBrowserViewAfterLayout()),
           onResizeEnd = Some(() => resizeBrowserView()),
           primary = SplitPane.Primary.Props(
             className = Some("browser-history-sidebar")

--- a/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/browser/BrowserShell.scala
@@ -59,7 +59,8 @@ object BrowserShell {
       timelineWidth: Int,
       onTimelineOpenChange: Boolean => Unit,
       onTimelineWidthChange: Int => Unit,
-      onStateChange: (String, Option[String]) => Unit
+      onStateChange: (String, Option[String]) => Unit,
+      onHistoryEntryDelete: (App.BrowserHistoryEntry, Int) => Unit
   )
 
   private def normalizeUrl(input: String): Option[String] = {
@@ -365,45 +366,68 @@ object BrowserShell {
         displayUrl: String,
         entryKey: Option[String] = None
     ): ReactElement = {
-      val current = entry.url == actualUrl
+      val currentEntry = props.model.history.entryForUrl(actualUrl)
+      val current = currentEntry.exists(_.url == entry.url)
+      val canDelete =
+        !current && !(level == 1 && currentEntry.exists(_.origin == entry.origin))
       val entryClass = optionalClasses(
         Seq(
           (s"browser-history-entry level-${level}", true),
           ("current", current)
         )
       )
-      val content =
+      val deleteButton = Option.when(canDelete) {
         button(
+          className := "browser-history-delete",
           `type` := "button",
-          title := entry.url,
-          onMouseDown := (e => e.preventDefault()),
-          onClick := (_ => navigateToHistory(entry.url))
+          title := "Delete",
+          onMouseDown := (e => {
+            e.preventDefault()
+            e.stopPropagation()
+          }),
+          onClick := (e => {
+            e.stopPropagation()
+            props.onHistoryEntryDelete(entry, level)
+          })
         )(
-          span(className := "browser-history-favicon")(
-            materialSymbol("language"),
-            img(
-              alt := "",
-              src := entry.faviconUrl,
-              onError := (e =>
-                e.currentTarget
-                  .asInstanceOf[dom.HTMLImageElement]
-                  .style
-                  .display = "none"
-              )
-            )
-          ),
-          span(className := "browser-history-text")(
-            span(className := "browser-history-title")(entry.label),
-            span(className := "browser-history-url")(displayUrl)
-          )
+          materialSymbol("delete")
         )
+      }
+      val content =
+        Seq(
+          button(
+            className := "browser-history-open",
+            `type` := "button",
+            title := entry.url,
+            onMouseDown := (e => e.preventDefault()),
+            onClick := (_ => navigateToHistory(entry.url))
+          )(
+            span(className := "browser-history-favicon")(
+              materialSymbol("language"),
+              img(
+                alt := "",
+                src := entry.faviconUrl,
+                onError := (e =>
+                  e.currentTarget
+                    .asInstanceOf[dom.HTMLImageElement]
+                    .style
+                    .display = "none"
+                )
+              )
+            ),
+            span(className := "browser-history-text")(
+              span(className := "browser-history-title")(entry.label),
+              span(className := "browser-history-url")(displayUrl)
+            )
+          )
+        ) ++ deleteButton.toSeq
       entryKey match {
         case Some(value) =>
           li(className := entryClass, key := value)(
-            content
+            content*
           )
         case None =>
-          li(className := entryClass)(content)
+          li(className := entryClass)(content*)
       }
     }
 

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/Text.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/Text.scala
@@ -223,8 +223,8 @@ trait Text {
 
   val BrowserShell_forward: String
   val BrowserShell_reload: String
-  val BrowserShell_history: String
-  val BrowserShell_historyEmpty: String
+  val BrowserShell_trail: String
+  val BrowserShell_trailEmpty: String
   val BrowserShell_go: String
   val BrowserShell_loadingPage: String
   val BrowserShell_pageReady: String

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/Text.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/Text.scala
@@ -223,6 +223,8 @@ trait Text {
 
   val BrowserShell_forward: String
   val BrowserShell_reload: String
+  val BrowserShell_history: String
+  val BrowserShell_historyEmpty: String
   val BrowserShell_go: String
   val BrowserShell_loadingPage: String
   val BrowserShell_pageReady: String

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/de.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/de.scala
@@ -285,8 +285,8 @@ object de extends Text {
 
   val BrowserShell_forward = "Vor"
   val BrowserShell_reload = "Neu laden"
-  val BrowserShell_history = "Verlauf"
-  val BrowserShell_historyEmpty = "Noch kein Browserverlauf."
+  val BrowserShell_trail = "Trail"
+  val BrowserShell_trailEmpty = "No browsing trail yet."
   val BrowserShell_go = "Aufrufen"
   val BrowserShell_loadingPage = "Seite wird geladen..."
   val BrowserShell_pageReady = "Seite bereit."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/de.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/de.scala
@@ -285,6 +285,8 @@ object de extends Text {
 
   val BrowserShell_forward = "Vor"
   val BrowserShell_reload = "Neu laden"
+  val BrowserShell_history = "Verlauf"
+  val BrowserShell_historyEmpty = "Noch kein Browserverlauf."
   val BrowserShell_go = "Aufrufen"
   val BrowserShell_loadingPage = "Seite wird geladen..."
   val BrowserShell_pageReady = "Seite bereit."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/en.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/en.scala
@@ -283,6 +283,8 @@ object en extends Text {
 
   val BrowserShell_forward = "Forward"
   val BrowserShell_reload = "Reload"
+  val BrowserShell_history = "History"
+  val BrowserShell_historyEmpty = "No browsing history yet."
   val BrowserShell_go = "Go"
   val BrowserShell_loadingPage = "Loading page..."
   val BrowserShell_pageReady = "Page ready."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/en.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/en.scala
@@ -283,8 +283,8 @@ object en extends Text {
 
   val BrowserShell_forward = "Forward"
   val BrowserShell_reload = "Reload"
-  val BrowserShell_history = "History"
-  val BrowserShell_historyEmpty = "No browsing history yet."
+  val BrowserShell_trail = "Trail"
+  val BrowserShell_trailEmpty = "No browsing trail yet."
   val BrowserShell_go = "Go"
   val BrowserShell_loadingPage = "Loading page..."
   val BrowserShell_pageReady = "Page ready."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/es.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/es.scala
@@ -285,6 +285,8 @@ object es extends Text {
 
   val BrowserShell_forward = "Adelante"
   val BrowserShell_reload = "Recargar"
+  val BrowserShell_history = "Historial"
+  val BrowserShell_historyEmpty = "Aún no hay historial."
   val BrowserShell_go = "Ir"
   val BrowserShell_loadingPage = "Cargando página..."
   val BrowserShell_pageReady = "Página lista."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/es.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/es.scala
@@ -285,8 +285,8 @@ object es extends Text {
 
   val BrowserShell_forward = "Adelante"
   val BrowserShell_reload = "Recargar"
-  val BrowserShell_history = "Historial"
-  val BrowserShell_historyEmpty = "Aún no hay historial."
+  val BrowserShell_trail = "Trail"
+  val BrowserShell_trailEmpty = "No browsing trail yet."
   val BrowserShell_go = "Ir"
   val BrowserShell_loadingPage = "Cargando página..."
   val BrowserShell_pageReady = "Página lista."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/fr.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/fr.scala
@@ -285,6 +285,8 @@ object fr extends Text {
 
   val BrowserShell_forward = "Suivant"
   val BrowserShell_reload = "Recharger"
+  val BrowserShell_history = "Historique"
+  val BrowserShell_historyEmpty = "Aucun historique pour le moment."
   val BrowserShell_go = "Aller"
   val BrowserShell_loadingPage = "Chargement de la page..."
   val BrowserShell_pageReady = "Page prête."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/fr.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/fr.scala
@@ -285,8 +285,8 @@ object fr extends Text {
 
   val BrowserShell_forward = "Suivant"
   val BrowserShell_reload = "Recharger"
-  val BrowserShell_history = "Historique"
-  val BrowserShell_historyEmpty = "Aucun historique pour le moment."
+  val BrowserShell_trail = "Trail"
+  val BrowserShell_trailEmpty = "No browsing trail yet."
   val BrowserShell_go = "Aller"
   val BrowserShell_loadingPage = "Chargement de la page..."
   val BrowserShell_pageReady = "Page prête."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ja.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ja.scala
@@ -281,8 +281,8 @@ object ja extends Text {
 
   val BrowserShell_forward = "進む"
   val BrowserShell_reload = "再読み込み"
-  val BrowserShell_history = "履歴"
-  val BrowserShell_historyEmpty = "閲覧履歴はまだありません。"
+  val BrowserShell_trail = "トレイル"
+  val BrowserShell_trailEmpty = "閲覧トレイルはまだありません。"
   val BrowserShell_go = "移動"
   val BrowserShell_loadingPage = "ページを読み込み中..."
   val BrowserShell_pageReady = "ページを表示しました。"

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ja.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ja.scala
@@ -281,6 +281,8 @@ object ja extends Text {
 
   val BrowserShell_forward = "進む"
   val BrowserShell_reload = "再読み込み"
+  val BrowserShell_history = "履歴"
+  val BrowserShell_historyEmpty = "閲覧履歴はまだありません。"
   val BrowserShell_go = "移動"
   val BrowserShell_loadingPage = "ページを読み込み中..."
   val BrowserShell_pageReady = "ページを表示しました。"

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ko.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ko.scala
@@ -283,8 +283,8 @@ object ko extends Text {
 
   val BrowserShell_forward = "앞으로"
   val BrowserShell_reload = "새로고침"
-  val BrowserShell_history = "기록"
-  val BrowserShell_historyEmpty = "아직 방문 기록이 없습니다."
+  val BrowserShell_trail = "트레일"
+  val BrowserShell_trailEmpty = "아직 방문 트레일이 없습니다."
   val BrowserShell_go = "이동"
   val BrowserShell_loadingPage = "페이지를 불러오는 중..."
   val BrowserShell_pageReady = "페이지가 준비되었습니다."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ko.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/ko.scala
@@ -283,6 +283,8 @@ object ko extends Text {
 
   val BrowserShell_forward = "앞으로"
   val BrowserShell_reload = "새로고침"
+  val BrowserShell_history = "기록"
+  val BrowserShell_historyEmpty = "아직 방문 기록이 없습니다."
   val BrowserShell_go = "이동"
   val BrowserShell_loadingPage = "페이지를 불러오는 중..."
   val BrowserShell_pageReady = "페이지가 준비되었습니다."

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_cn.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_cn.scala
@@ -283,6 +283,8 @@ object zh_cn extends Text {
 
   val BrowserShell_forward = "前进"
   val BrowserShell_reload = "重新加载"
+  val BrowserShell_history = "历史记录"
+  val BrowserShell_historyEmpty = "暂无浏览历史。"
   val BrowserShell_go = "前往"
   val BrowserShell_loadingPage = "正在加载页面..."
   val BrowserShell_pageReady = "页面已就绪。"

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_cn.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_cn.scala
@@ -283,8 +283,8 @@ object zh_cn extends Text {
 
   val BrowserShell_forward = "前进"
   val BrowserShell_reload = "重新加载"
-  val BrowserShell_history = "历史记录"
-  val BrowserShell_historyEmpty = "暂无浏览历史。"
+  val BrowserShell_trail = "浏览轨迹"
+  val BrowserShell_trailEmpty = "暂无浏览轨迹。"
   val BrowserShell_go = "前往"
   val BrowserShell_loadingPage = "正在加载页面..."
   val BrowserShell_pageReady = "页面已就绪。"

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_tw.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_tw.scala
@@ -283,6 +283,8 @@ object zh_tw extends Text {
 
   val BrowserShell_forward = "前進"
   val BrowserShell_reload = "重新載入"
+  val BrowserShell_history = "歷史記錄"
+  val BrowserShell_historyEmpty = "暫無瀏覽歷史。"
   val BrowserShell_go = "前往"
   val BrowserShell_loadingPage = "正在載入頁面..."
   val BrowserShell_pageReady = "頁面已就緒。"

--- a/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_tw.scala
+++ b/cotoami_desktop/ui/src/main/scala/cotoami/i18n/text/zh_tw.scala
@@ -283,8 +283,8 @@ object zh_tw extends Text {
 
   val BrowserShell_forward = "前進"
   val BrowserShell_reload = "重新載入"
-  val BrowserShell_history = "歷史記錄"
-  val BrowserShell_historyEmpty = "暫無瀏覽歷史。"
+  val BrowserShell_trail = "瀏覽軌跡"
+  val BrowserShell_trailEmpty = "暫無瀏覽軌跡。"
   val BrowserShell_go = "前往"
   val BrowserShell_loadingPage = "正在載入頁面..."
   val BrowserShell_pageReady = "頁面已就緒。"

--- a/cotoami_desktop/ui/src/main/scala/marubinotto/components/SplitPane.scala
+++ b/cotoami_desktop/ui/src/main/scala/marubinotto/components/SplitPane.scala
@@ -22,6 +22,7 @@ object SplitPane {
       resize: Action[Int] = Action.default,
       className: Option[String] = None,
       onResizeStart: Option[() => Unit] = None,
+      onResizing: Option[Int => Unit] = None,
       onResizeEnd: Option[() => Unit] = None,
       onPrimarySizeChanged: Option[Int => Unit] = None,
       primary: Primary.Props,
@@ -36,6 +37,7 @@ object SplitPane {
       resize: Action[Int] = Action.default,
       className: Option[String] = None,
       onResizeStart: Option[() => Unit] = None,
+      onResizing: Option[Int => Unit] = None,
       onResizeEnd: Option[() => Unit] = None,
       onPrimarySizeChanged: Option[Int => Unit] = None,
       primary: Primary.Props,
@@ -50,6 +52,7 @@ object SplitPane {
         resize,
         className,
         onResizeStart,
+        onResizing,
         onResizeEnd,
         onPrimarySizeChanged,
         primary,
@@ -131,9 +134,10 @@ object SplitPane {
             }
 
             setPrimarySize(newSize)
+            props.onResizing.foreach(_(newSize))
           }
         },
-        Seq(props.vertical, props.reverse)
+        Seq(props.vertical, props.reverse, props.onResizing)
       )
 
     val onMouseUp: js.Function1[dom.MouseEvent, Unit] = useCallback(


### PR DESCRIPTION
The Browsing Trail is a session-only sidebar for the in-app browser. It records visited pages grouped by domain: the first page opened in a domain becomes the parent entry, and later pages in that same domain appear beneath it.

The Trail can be toggled from the toolbar, highlights the current page, supports deleting non-current entries, shows favicons/titles/URLs, and keeps a stable reverse order so entries do not jump around when clicked.